### PR TITLE
[CCA-2] Adds first assessment Selenium test.

### DIFF
--- a/src/main/java/miss/pell/ted/rvcctestjg/Launcher.java
+++ b/src/main/java/miss/pell/ted/rvcctestjg/Launcher.java
@@ -1,11 +1,10 @@
 package miss.pell.ted.rvcctestjg;
 
+import miss.pell.ted.rvcctestjg.cases.NavigationBackgroundChangesWhenPageScrolled;
 import miss.pell.ted.rvcctestjg.drivers.FirefoxDriverFactory;
-import miss.pell.ted.rvcctestjg.examples.GoogleSearchTermInPageTitleAfterSubmission;
 import miss.pell.ted.rvcctestjg.drivers.HtmlUnitDriverFactory;
 import miss.pell.ted.rvcctestjg.drivers.HtmlUnitWithJsDriverFactory;
 import miss.pell.ted.rvcctestjg.drivers.WebDriverFactory;
-import miss.pell.ted.rvcctestjg.examples.GoogleSuggestReturnsSuggestionsAfterSubmission;
 import org.openqa.selenium.WebDriver;
 
 import java.io.FileInputStream;
@@ -119,8 +118,12 @@ public class Launcher {
 
                     List<SeleniumTest> testPlan = new ArrayList<>(0);
 
-                    testPlan.add(GoogleSearchTermInPageTitleAfterSubmission.searchFor("Cheese!"));
-                    testPlan.add(GoogleSuggestReturnsSuggestionsAfterSubmission.suggestFor("Cheese"));
+                    // Example adapted Selenium tests.
+//                    testPlan.add(GoogleSearchTermInPageTitleAfterSubmission.searchFor("Cheese!"));
+//                    testPlan.add(GoogleSuggestReturnsSuggestionsAfterSubmission.suggestFor("Cheese"));
+
+                    // Assessment Selenium tests.
+                    testPlan.add(new NavigationBackgroundChangesWhenPageScrolled());
 
                     for (SeleniumTest test : testPlan) {
                         runTest(test, webDriverFactory);

--- a/src/main/java/miss/pell/ted/rvcctestjg/cases/NavigationBackgroundChangesWhenPageScrolled.java
+++ b/src/main/java/miss/pell/ted/rvcctestjg/cases/NavigationBackgroundChangesWhenPageScrolled.java
@@ -1,0 +1,53 @@
+package miss.pell.ted.rvcctestjg.cases;
+
+import miss.pell.ted.rvcctestjg.SeleniumTest;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebElement;
+
+public class NavigationBackgroundChangesWhenPageScrolled extends SeleniumTest {
+
+    private static final String ATTRIBUTE_CLASS = "class";
+    private static final String CLASS_STYLE_TRANSPARENT_NAV = "transparent-nav";
+
+    @Override
+    public String id() {
+        return "[CC] Navigation Background Changes when Page Scrolled";
+    }
+
+    private boolean isTransparent(WebElement element) {
+        return element.getAttribute(ATTRIBUTE_CLASS).contains(CLASS_STYLE_TRANSPARENT_NAV);
+    }
+
+    @Override
+    public void run() {
+        webDriver().get("http://www.creditcards.com");
+
+        // First get the indication that the initial transparency is the situation.
+        WebElement header = webDriver().findElement(By.xpath("//header"));
+
+        // Check to see that the 'transparent-nav' style class is applied to the header element.
+        boolean transparent = isTransparent(header);
+
+        if (transparent) {
+            // Scroll down a little.
+            ((JavascriptExecutor) webDriver()).executeScript("scroll(0, 100);");
+
+            // Wait up to 8 seconds.
+            long end = System.currentTimeMillis() + 8000;
+            while (System.currentTimeMillis() < end && transparent) {
+                transparent = isTransparent(header);
+            }
+
+            // If the transparency is still there, then the class style was not removed.
+            if (isTransparent(header)) {
+                fail("The transparent-nav class was not removed when the page was scrolled.");
+            }
+        } else {
+            fail("The header element did not have the initial transparent-nav CSS class.");
+        }
+
+        webDriver().quit();
+    }
+
+}


### PR DESCRIPTION
The first test verifies that when the page is scrolled downwards, the navigation bar background loses the
transparent-nav class style.

Tested with the FirefoxDriver, although there are some JavaScript errors in the log. The other two WebDrivers
fail, due to the lack of JavaScript being enabled in the HtmlUnitDriver by default behavior, and in the
HtmlUnitWithJsDriver due to additional Js errors (most likely related to how Rhino works).

This test could be expanded/duplicated to verify that when the user/agent scrolls back up to the top, the
transparent-nav class style is added back to the header element.

As an asside, the two example Selenium tests adapted from Getting Started with Selenium, as they are no longer
the focus of this project.