### PR TITLE
[CCA-3] Adds the second Selenium test case.

### DIFF
--- a/src/main/java/miss/pell/ted/rvcctestjg/Launcher.java
+++ b/src/main/java/miss/pell/ted/rvcctestjg/Launcher.java
@@ -1,5 +1,6 @@
 package miss.pell.ted.rvcctestjg;
 
+import miss.pell.ted.rvcctestjg.cases.AdvertiserDisclosureStatementsEqual;
 import miss.pell.ted.rvcctestjg.cases.NavigationBackgroundChangesWhenPageScrolled;
 import miss.pell.ted.rvcctestjg.drivers.FirefoxDriverFactory;
 import miss.pell.ted.rvcctestjg.drivers.HtmlUnitDriverFactory;
@@ -124,6 +125,7 @@ public class Launcher {
 
                     // Assessment Selenium tests.
                     testPlan.add(new NavigationBackgroundChangesWhenPageScrolled());
+                    testPlan.add(new AdvertiserDisclosureStatementsEqual());
 
                     for (SeleniumTest test : testPlan) {
                         runTest(test, webDriverFactory);

--- a/src/main/java/miss/pell/ted/rvcctestjg/cases/AdvertiserDisclosureStatementsEqual.java
+++ b/src/main/java/miss/pell/ted/rvcctestjg/cases/AdvertiserDisclosureStatementsEqual.java
@@ -1,0 +1,50 @@
+package miss.pell.ted.rvcctestjg.cases;
+
+import miss.pell.ted.rvcctestjg.SeleniumTest;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+public class AdvertiserDisclosureStatementsEqual extends SeleniumTest {
+    @Override
+    public String id() {
+        return "[CC] Advertiser Disclosures Statements Equal";
+    }
+
+    @Override
+    public void run() {
+        webDriver().get("http://www.creditcards.com");
+
+        // First get the indication that the initial transparency is the situation.
+        WebElement label = webDriver().findElement(By.xpath("//section/div[2]/div/label"));
+
+        // Click the label to activate the modal dialog.
+        label.click();
+
+        // Get the modal dialog contents (excluding title) in preparation for the comparison.
+        WebElement modalInnerDiv = webDriver().findElement(By.className("modal__inner"));
+        WebElement modalDialogP = modalInnerDiv.findElement(By.xpath("./p"));
+
+        String dialogContents = modalDialogP.getText();
+
+        WebElement modalOkButton = modalInnerDiv.findElement(By.className("modal__ok-button"));
+
+        // Dismiss the modal dialog.
+        modalOkButton.click();
+
+        // Get the contents of the advertiser disclosure in the footer of the page.
+        WebElement disclosureSpan = webDriver().findElement(By.className("footer__adDisclosureText"));
+
+        // Remove the screaming capitalization-locked characters at the beginning.
+        String footerContents = disclosureSpan.getText().replace("ADVERTISER DISCLOSURE ", "");
+
+        if (!footerContents.equals(dialogContents)) {
+            fail("The modal dialog Advertiser Disclosure does not equal the footer Advertiser Disclosure.");
+
+            System.out.printf("DAD: %s\n", dialogContents);
+            System.out.printf("FAD: %s\n", footerContents);
+        }
+
+        webDriver().quit();
+    }
+
+}


### PR DESCRIPTION
This test case checks for equality between the two Advertiser Disclosures on the landing page, the first
behind a label/link that requires the user to click to see, and the second in the footer of the page.

Bonus Achieved! They aren't the same. Which one is the more correct? I believe they have the same... ah..
(non-legalese) intent (?) behind them, so I don't think it's too big a deal, but still, would be nice to
have the same disclosure.

At least there is a nice link with sizable text not buried in the footer to inform the user about the
Disclosure, which is really nice!